### PR TITLE
[src/os/unix/udsocket/{ancillary.rs,util.rs}] Casts to fix build; use non-namespaced `size_of`

### DIFF
--- a/src/os/unix/udsocket/ancillary.rs
+++ b/src/os/unix/udsocket/ancillary.rs
@@ -51,7 +51,7 @@ impl<'a> AncillaryData<'a> {
         } /*else if #[cfg(uds_xucred)] {
             const _ENCODED_SIZE_OF_CREDENTIALS: usize = mem::size_of::<cmsghdr>() + size_of::<xucred>();
         } */else if #[cfg(unix)] {
-            const _ENCODED_SIZE_OF_CREDENTIALS: usize = mem::size_of::<cmsghdr>();
+            const _ENCODED_SIZE_OF_CREDENTIALS: usize = size_of::<cmsghdr>();
         } else {
             const _ENCODED_SIZE_OF_CREDENTIALS: usize = 0;
         }

--- a/src/os/unix/udsocket/util.rs
+++ b/src/os/unix/udsocket/util.rs
@@ -185,9 +185,9 @@ fn _fill_out_msghdr(
     anclen: usize,
 ) -> io::Result<()> {
     hdr.msg_iov = iov;
-    hdr.msg_iovlen = to_msghdrsize(iovlen)?;
+    hdr.msg_iovlen = to_msghdrsize(iovlen)? as i32;
     hdr.msg_control = anc as *mut _;
-    hdr.msg_controllen = to_msghdrsize(anclen)?;
+    hdr.msg_controllen = to_msghdrsize(anclen)? as u32;
     Ok(())
 }
 pub fn mk_msghdr_r(iov: &mut [IoSliceMut<'_>], anc: &mut [u8]) -> io::Result<msghdr> {


### PR DESCRIPTION
Now builds without error on macOS. Haven't tested on other OSs (might need conditional casting).