### PR TITLE
ToLocalSocketName implementation for LocalSocketName

### DIFF
--- a/src/local_socket/to_name.rs
+++ b/src/local_socket/to_name.rs
@@ -59,6 +59,12 @@ pub trait ToLocalSocketName<'a> {
     fn to_local_socket_name(self) -> io::Result<LocalSocketName<'a>>;
 }
 
+impl<'a> ToLocalSocketName<'a> for LocalSocketName<'a> {
+    fn to_local_socket_name(self) -> io::Result<LocalSocketName<'a>> {
+        Ok(self)
+    }
+}
+
 /// Converts a borrowed [`Path`] to a borrowed file-type [`LocalSocketName`] with the same lifetime.
 impl<'a> ToLocalSocketName<'a> for &'a Path {
     fn to_local_socket_name(self) -> io::Result<LocalSocketName<'a>> {

--- a/src/local_socket/to_name.rs
+++ b/src/local_socket/to_name.rs
@@ -59,6 +59,7 @@ pub trait ToLocalSocketName<'a> {
     fn to_local_socket_name(self) -> io::Result<LocalSocketName<'a>>;
 }
 
+/// Returns self.
 impl<'a> ToLocalSocketName<'a> for LocalSocketName<'a> {
     fn to_local_socket_name(self) -> io::Result<LocalSocketName<'a>> {
         Ok(self)


### PR DESCRIPTION
A very simple change: `LocalSocketName<'a>` now implements `ToLocalSocketName<'a>` as well.