### PR TITLE
Remove `to_method` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,6 @@ dependencies = [
  "color-eyre",
  "libc",
  "recvmsg",
- "to_method",
  "tokio",
  "windows-sys",
 ]
@@ -265,12 +264,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
-
-[[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { version = "1.32.0", features = [
     "time",
     "io-util",
 ], optional = true }
-to_method = "1.1"
 cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/local_socket/to_name.rs
+++ b/src/local_socket/to_name.rs
@@ -6,7 +6,6 @@ use std::{
     path::{Path, PathBuf},
     str,
 };
-use to_method::To;
 
 impmod! {local_socket,
     cstr_to_osstr,
@@ -119,7 +118,7 @@ impl<'a> ToLocalSocketName<'a> for &'a OsStr {
 impl ToLocalSocketName<'static> for OsString {
     fn to_local_socket_name(mut self) -> io::Result<LocalSocketName<'static>> {
         let mut namespaced = false;
-        let mut bytes = self.into_encoded_bytes().to::<Vec<_>>();
+        let mut bytes = Into::<Vec<_>>::into(self.into_encoded_bytes());
         if bytes.first() == Some(&b'@') {
             bytes.remove(0);
             namespaced = true;

--- a/src/os/unix/fdops.rs
+++ b/src/os/unix/fdops.rs
@@ -4,7 +4,6 @@ use std::{
     io::{self, prelude::*, IoSlice, IoSliceMut},
     os::fd::OwnedFd,
 };
-use to_method::To;
 
 #[repr(transparent)]
 pub(super) struct FdOps(pub(super) OwnedFd);
@@ -20,7 +19,7 @@ impl Read for &FdOps {
         ok_or_ret_errno!(success => bytes_read)
     }
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        let num_bufs = bufs.len().try_to::<c_int>().unwrap_or(c_int::MAX);
+        let num_bufs = TryInto::<c_int>::try_into(bufs.len()).unwrap_or(c_int::MAX);
 
         let (success, bytes_read) = unsafe {
             let size_or_err = libc::readv(self.0.as_raw_fd(), bufs.as_ptr().cast(), num_bufs);
@@ -41,7 +40,7 @@ impl Write for &FdOps {
         ok_or_ret_errno!(success => bytes_written)
     }
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let num_bufs = bufs.len().try_to::<c_int>().unwrap_or(c_int::MAX);
+        let num_bufs = TryInto::<c_int>::try_into(bufs.len()).unwrap_or(c_int::MAX);
 
         let (success, bytes_written) = unsafe {
             let size_or_err = libc::writev(self.0.as_raw_fd(), bufs.as_ptr().cast(), num_bufs);

--- a/src/os/windows/named_pipe/listener.rs
+++ b/src/os/windows/named_pipe/listener.rs
@@ -16,7 +16,6 @@ use std::{
         Mutex,
     },
 };
-use to_method::To;
 use windows_sys::Win32::{
     Foundation::ERROR_PIPE_CONNECTED,
     Security::SECURITY_ATTRIBUTES,

--- a/tests/util/drive.rs
+++ b/tests/util/drive.rs
@@ -6,7 +6,6 @@ use std::{
     sync::mpsc::{channel, /*Receiver,*/ Sender},
     thread,
 };
-use to_method::*;
 
 /// Waits for the leader closure to reach a point where it sends a message for the follower closure,
 /// then runs the follower. Captures Eyre errors on both sides and bubbles them up if they occur,
@@ -78,7 +77,7 @@ where
 
     let client_wrapper = |msg: T| {
         thread::scope(|scope| {
-            let mut client_threads = Vec::with_capacity(NUM_CLIENTS.try_to().unwrap());
+            let mut client_threads = Vec::with_capacity(TryInto::try_into(NUM_CLIENTS).unwrap());
             for n in 1..=NUM_CLIENTS {
                 let tname = format!("client {n}");
 


### PR DESCRIPTION
The `to_method` crate is licensed with CC0. The CC0 license is primarily intended for non-software work and is not recommended for software works due to the explicit lack of patent grants.

The `to_method` crate only adds suffix notation for conversion functions.

This commit removes the dependency and uses the standard prefix notations instead.

https://www.gnu.org/licenses/license-list.en.html#CC0