### PR TITLE
Fixes for Android / Termux

### DIFF
--- a/tests/util/namegen.rs
+++ b/tests/util/namegen.rs
@@ -56,7 +56,11 @@ fn windows_path(rn: u32) -> String {
 	format!(r"\\.\pipe\interprocess-test-{rn:08x}")
 }
 fn unix_path(rn: u32) -> String {
-	format!("/tmp/interprocess-test-{rn:08x}.sock")
+	let tmpdir = std::env::var("TMPDIR").ok();
+	format!(
+		"{}/interprocess-test-{rn:08x}.sock",
+		tmpdir.as_deref().unwrap_or("/tmp")
+	)
 }
 
 macro_rules! make_id {


### PR DESCRIPTION
Fix the following issues for Android:

- `std::os::linux` was assumed to be available, but it's actually `std::os::android`
- `/tmp` is used as the base path by default, but `TMPDIR` must be used on Termux
- `c_char` was assumed to be `i8`, but it's actually `u8` on aarch64

Can confirm that the tests pass with this patch under Termux on both x86_64 and aarch64. I have not tested 32-bit architectures.
