### PR TITLE
fix: compilation on 32-bit Linux where `tv_nsec` is `i32`

### DIFF
--- a/src/os/unix/c_wrappers.rs
+++ b/src/os/unix/c_wrappers.rs
@@ -429,5 +429,5 @@ fn duration_to_timespec(d: Duration) -> io::Result<libc::timespec> {
     let tv_sec = libc::time_t::try_from(d.as_secs()).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "timeout duration overflowed time_t")
     })?;
-    Ok(libc::timespec { tv_sec, tv_nsec: d.subsec_nanos().into() })
+    Ok(libc::timespec { tv_sec, tv_nsec: d.subsec_nanos() as _ })
 }


### PR DESCRIPTION
`Duration::subsec_nanos()` returns `u32`, which has no `From<u32>` impl for `i32`. Use `as` cast instead since the value is always in range.

build test:
https://github.com/libnyanpasu/nyanpasu-service/actions/runs/21776022060

before:
https://github.com/libnyanpasu/clash-nyanpasu/actions/runs/21771034096/job/62818468131

after:
https://github.com/libnyanpasu/clash-nyanpasu/actions/runs/21777373123/job/62836899646