### PR TITLE
fix: Update 'bytes' dependency for vulnerability fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
1.11.0 -> 1.11.1

* https://github.com/tokio-rs/bytes/releases/tag/v1.11.1
* https://github.com/advisories/GHSA-434x-w66g-qw3r

`cargo audit` output:

```
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1049 security advisories (from C:\cache\cargo\advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (65 crate dependencies)
Crate:     bytes
Version:   1.11.0
Title:     Integer overflow in `BytesMut::reserve`
Date:      2026-02-03
ID:        RUSTSEC-2026-0007
URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
Solution:  Upgrade to >=1.11.1
Dependency tree:
bytes 1.11.0
└── tokio 1.48.0
    └── interprocess 2.4.0
```
