### PR TITLE
chore: Upgrade 'windows-sys' 0.52.0 -> 0.61.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -374,20 +374,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -401,42 +392,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -446,21 +415,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -470,21 +427,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -494,33 +439,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ tokio = { version = "1.36.0", features = [
 futures-core = { version = "0.3.28", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52.0", features = [
+windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",

--- a/src/os/windows/adv_handle.rs
+++ b/src/os/windows/adv_handle.rs
@@ -38,7 +38,7 @@ impl<const TAG0: bool, const TAG1: bool> AdvOwnedHandle<TAG0, TAG1> {
     fn new(h: OwnedHandle, tag0: bool, tag1: bool) -> Self {
         // SAFETY: valid handles (as guaranteed by OwnedHandle) are never zero
         Self(unsafe {
-            NonZeroIsize::new_unchecked(h.into_int_handle() | Self::mk_tag(tag0, tag1))
+            NonZeroIsize::new_unchecked((h.into_int_handle() as isize) | Self::mk_tag(tag0, tag1))
         })
     }
     #[inline(always)]
@@ -116,7 +116,7 @@ impl<const TAG0: bool, const TAG1: bool> AsHandle for AdvOwnedHandle<TAG0, TAG1>
 impl From<OwnedHandle> for AdvOwnedHandle<false, false> {
     #[inline(always)]
     fn from(h: OwnedHandle) -> Self {
-        Self(unsafe { NonZeroIsize::new_unchecked(h.into_int_handle()) })
+        Self(unsafe { NonZeroIsize::new_unchecked(h.into_int_handle() as isize) })
     }
 }
 impl FromRawHandle for AdvOwnedHandle<false, false> {

--- a/src/os/windows/c_wrappers.rs
+++ b/src/os/windows/c_wrappers.rs
@@ -2,7 +2,7 @@ use {
     super::{downgrade_eof, winprelude::*},
     crate::{mut2ptr, timeout_expiry, AsBuf, CannotUnwind, OrErrno as _, SubUsizeExt as _},
     std::{
-        io, ptr,
+        ffi::c_void, io, ptr,
         time::{Duration, Instant},
     },
     windows_sys::{
@@ -33,7 +33,7 @@ struct CompletionResult {
 }
 impl CompletionResult {
     pub fn write_to_overlapped(&mut self, overlapped: &mut OVERLAPPED) {
-        overlapped.hEvent = self as *mut _ as isize
+        overlapped.hEvent = self as *mut _ as *mut c_void
     }
     #[allow(clippy::cast_sign_loss)] // not a number
     pub unsafe fn from_overlapped<'s>(overlapped: *mut OVERLAPPED) -> &'s mut Self {

--- a/src/os/windows/c_wrappers.rs
+++ b/src/os/windows/c_wrappers.rs
@@ -5,18 +5,21 @@ use {
         io, ptr,
         time::{Duration, Instant},
     },
-    windows_sys::Win32::{
-        Foundation::{
-            DuplicateHandle, GetLastError, BOOL, DUPLICATE_SAME_ACCESS, ERROR_IO_PENDING,
-            ERROR_NOT_FOUND, MAX_PATH, WAIT_IO_COMPLETION,
-        },
-        Storage::FileSystem::{
-            FlushFileBuffers, GetFinalPathNameByHandleW, ReadFile, ReadFileEx, WriteFile,
-            WriteFileEx,
-        },
-        System::{
-            Threading::{GetCurrentProcess, SleepEx},
-            IO::{CancelIoEx, OVERLAPPED},
+    windows_sys::{
+        core::BOOL,
+        Win32::{
+            Foundation::{
+                DuplicateHandle, GetLastError, DUPLICATE_SAME_ACCESS, ERROR_IO_PENDING,
+                ERROR_NOT_FOUND, MAX_PATH, WAIT_IO_COMPLETION,
+            },
+            Storage::FileSystem::{
+                FlushFileBuffers, GetFinalPathNameByHandleW, ReadFile, ReadFileEx, WriteFile,
+                WriteFileEx,
+            },
+            System::{
+                Threading::{GetCurrentProcess, SleepEx},
+                IO::{CancelIoEx, OVERLAPPED},
+            },
         },
     },
 };

--- a/src/os/windows/named_pipe/c_wrappers.rs
+++ b/src/os/windows/named_pipe/c_wrappers.rs
@@ -162,7 +162,7 @@ pub(crate) fn connect_without_waiting(
             ptr::null_mut(),
             OPEN_EXISTING,
             FILE_FLAG_OVERLAPPED,
-            0,
+            ptr::null_mut(),
         )
         .handle_or_errno()
         .map(|h|

--- a/src/os/windows/security_descriptor/c_wrappers.rs
+++ b/src/os/windows/security_descriptor/c_wrappers.rs
@@ -3,15 +3,18 @@ use {
     crate::{BoolExt, OrErrno, SubUsizeExt},
     std::{ffi::c_void, io, ptr},
     widestring::U16CStr,
-    windows_sys::Win32::{
-        Foundation::{LocalFree, BOOL, PSID},
-        Security::{
-            Authorization::{
-                ConvertSecurityDescriptorToStringSecurityDescriptorW,
-                ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+    windows_sys::{
+        core::BOOL,
+        Win32::{
+            Foundation::LocalFree,
+            Security::{
+                Authorization::{
+                    ConvertSecurityDescriptorToStringSecurityDescriptorW,
+                    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+                },
+                FreeSid, GetSecurityDescriptorControl, SetSecurityDescriptorControl, ACL,
+                SECURITY_DESCRIPTOR_CONTROL, PSID,
             },
-            FreeSid, GetSecurityDescriptorControl, SetSecurityDescriptorControl, ACL,
-            SECURITY_DESCRIPTOR_CONTROL,
         },
     },
 };

--- a/tests/os/windows/local_socket_security_descriptor/sd_graft.rs
+++ b/tests/os/windows/local_socket_security_descriptor/sd_graft.rs
@@ -89,7 +89,7 @@ fn get_self_exe(obuf: &mut [MaybeUninit<u16>]) -> io::Result<&U16CStr> {
     }
     let base = obuf.as_mut_ptr().cast();
     let cap = obuf.len().try_into().unwrap_or(u32::MAX);
-    unsafe { GetModuleFileNameW(0, base, cap) != 0 }.true_val_or_errno(()).and_then(|()| unsafe {
+    unsafe { GetModuleFileNameW(std::ptr::null_mut(), base, cap) != 0 }.true_val_or_errno(()).and_then(|()| unsafe {
         U16CStr::from_ptr_truncate(base.cast_const(), cap.to_usize()).map_err(io::Error::other)
     })
 }


### PR DESCRIPTION
* https://crates.io/crates/windows-sys/versions
* https://github.com/microsoft/windows-rs/releases

Resolves #96

I am not super familiar with Rust or WinAPI specifics, or these packages in particular.
I attempted to update the `windows-sys` dependency and resolve consequential breakage discovered by `cargo build` and `cargo test`. The namespace changes are fairly obvious and seem fairly safe. The other changes are argument type mismatches.

I am creating this as a draft PR hoping someone with the necessary expertise can verify the changes and identify any additional potential concerns.

I did not do any testing beyond running `cargo test` on my Windows 11 system.